### PR TITLE
Invert test in kernel version dependent package names

### DIFF
--- a/mediatree-kbuild.sh
+++ b/mediatree-kbuild.sh
@@ -648,7 +648,7 @@ function generate_virtual_package()
 	sed -i "s/__LINUX_KBUILD_PKG_SRC_NAME__/linux${deb_branch}-${1}-mediatree/g" ns_control
 	sed -i "s/__MAINTAINER_INFO__/${U_FULLNAME} <${U_EMAIL}>/" ns_control
 	sed -i "s/__LINUX_HEADER_PACKAGE__/linux-headers-${KVER}.${KMAJ}.${KMIN}-${K_ABI_A}${LAST_KBUILD_VER}-generic/" ns_control
-	if [ ${KVER} -gt 4 -o ${KVER} -eq 4 -a ${KMAJ} -lt 15 ] ; then
+	if [ ${KVER} -lt 4 -o ${KVER} -eq 4 -a ${KMAJ} -lt 15 ] ; then
 		sed -i "s/__LINUX_IMAGE_PACKAGES__/linux-image-${KVER}.${KMAJ}.${KMIN}-${K_ABI_A}${LAST_KBUILD_VER}-generic, linux-image-extra-${KVER}.${KMAJ}.${KMIN}-${K_ABI_A}${LAST_KBUILD_VER}-generic/" ns_control
 	else
 		sed -i "s/__LINUX_IMAGE_PACKAGES__/linux-image-unsigned-${KVER}.${KMAJ}.${KMIN}-${K_ABI_A}${LAST_KBUILD_VER}-generic, linux-modules-${KVER}.${KMAJ}.${KMIN}-${K_ABI_A}${LAST_KBUILD_VER}-generic, linux-modules-extra-${KVER}.${KMAJ}.${KMIN}-${K_ABI_A}${LAST_KBUILD_VER}-generic/" ns_control
@@ -659,7 +659,7 @@ function generate_virtual_package()
 	if [ "${1}" == "headers" ] ; then
 		echo "    linux-headers-${KVER}.${KMAJ}.${KMIN}-${K_ABI_A}${LAST_KBUILD_VER}-generic"
 	else
-		if [ ${KVER} -gt 4 -o ${KVER} -eq 4 -a ${KMAJ} -lt 15 ] ; then
+		if [ ${KVER} -lt 4 -o ${KVER} -eq 4 -a ${KMAJ} -lt 15 ] ; then
 			echo "    linux-image-${KVER}.${KMAJ}.${KMIN}-${K_ABI_A}${LAST_KBUILD_VER}-generic"
 			echo "    linux-image-extra-${KVER}.${KMAJ}.${KMIN}-${K_ABI_A}${LAST_KBUILD_VER}-generic"
 		else


### PR DESCRIPTION
Unless I'm mistaken the comparisons should match kernels older than 4.15.